### PR TITLE
Fix an issue with icons was not included in the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,10 +98,6 @@
         <resources>
             <resource>
                 <directory>resources/</directory>
-                <includes>
-                    <include>META-INF/plugin.xml</include>
-                    <include>icons/</include>
-                </includes>
                 <filtering>true</filtering>
             </resource>
         </resources>


### PR DESCRIPTION
A minor mistake was introduced when converting to maven build that it didn't include all resources