### PR TITLE
#136 Fix an issue with scanning for camel dependencies failed if the …

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
@@ -141,6 +141,9 @@ public class CamelService implements Disposable {
                         continue;
                     }
                     String[] split = name.split(":");
+                    if (split.length < 3) {
+                        continue;
+                    }
                     String groupId = split[1].trim();
                     String artifactId = split[2].trim();
                     String version = null;
@@ -221,6 +224,9 @@ public class CamelService implements Disposable {
                         continue;
                     }
                     String[] split = name.split(":");
+                    if (split.length < 3) {
+                        continue;
+                    }
                     String groupId = split[1].trim();
                     String artifactId = split[2].trim();
 

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/CamelProjectComponentTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/CamelProjectComponentTestIT.java
@@ -110,6 +110,24 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
         assertEquals(1, service.getLibraries().size());
     }
 
+    public void testAddLegacyPackaging() throws IOException {
+        CamelService service = ServiceManager.getService(myProject, CamelService.class);
+        assertEquals(0, service.getLibraries().size());
+
+        VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-2.19.0.jar"));
+        VirtualFile legacyJarPackagingFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("legacy-custom-file-0.12.snapshot.jar"));
+
+        final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(myProject);
+
+        addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-core:2.19.0-snapshot");
+        addLibraryToModule(legacyJarPackagingFile, projectLibraryTable, "c:\\test\\libs\\legacy-custom-file-0.12.snapshot.jar");
+
+        UIUtil.dispatchAllInvocationEvents();
+        assertEquals(1, service.getLibraries().size());
+        assertEquals(true, service.getLibraries().contains("camel-core"));
+
+    }
+
     private File createTestArchive(String filename) throws IOException {
         JavaArchive archive = ShrinkWrap.create(JavaArchive.class, filename)
             .addClasses(CamelService.class);


### PR DESCRIPTION
…name was not present in the typical pattern groupid:artifactid:version.

This could happen if the user add custom jar files the project