### PR TITLE
fix NullPointerException in AbstractCamelAnnotator.java

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/AbstractCamelAnnotator.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/AbstractCamelAnnotator.java
@@ -62,6 +62,11 @@ abstract class AbstractCamelAnnotator implements Annotator {
      * @return <ttt>true</ttt> to accept or <tt>false</tt> to drop
      */
     boolean accept(PsiElement element) {
+
+        if (element == null || element.getNode() == null) {
+            return false;
+        }
+
         // skip whitespace noise
         IElementType type = element.getNode().getElementType();
         if (type == TokenType.WHITE_SPACE) {


### PR DESCRIPTION
	at org.apache.camel.idea.annotator.AbstractCamelAnnotator.accept(AbstractCamelAnnotator.java:66)
	at org.apache.camel.idea.annotator.AbstractCamelAnnotator.annotate(AbstractCamelAnnotator.java:49)
	at org.apache.camel.idea.annotator.CamelEndpointAnnotator.annotate(CamelEndpointAnnotator.java:45)
	at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.a(DefaultHighlightVisitor.java:139)
	at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.visit(DefaultHighlightVisitor.java:102)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:367)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:306)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:326)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:329)
	at com.intellij.codeInsight.daemon.impl.analysis.HighlightVisitorImpl.a(HighlightVisitorImpl.java:172)
	at com.intellij.codeInsight.daemon.impl.analysis.RefCountHolder.analyze(RefCountHolder.java:335)
	at com.intellij.codeInsight.daemon.impl.analysis.HighlightVisitorImpl.analyze(HighlightVisitorImpl.java:171)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:329)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:329)
	at com.intellij.codeInsight.daemon.impl.analysis.XmlHighlightVisitor.analyze(XmlHighlightVisitor.java:745)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:329)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:329)