### PR TITLE
Added unit test for quick documentation popup

### DIFF
--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/CamelLightCodeInsightFixtureTestCaseIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/CamelLightCodeInsightFixtureTestCaseIT.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.psi.PsiElement;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.PsiTestUtil;
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor;
@@ -90,6 +91,14 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightCodeIn
             .withoutTransitivity().asFile();
 
         return libs;
+    }
+
+    protected PsiElement getElementAtCaret() {
+        int offset = myFixture.getCaretOffset();
+        if (offset < 0) {
+            fail("No <caret> found");
+        }
+        return myFixture.getFile().findElementAt(offset);
     }
 
     public boolean isIgnoreCamelCoreLib() {

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelSmartCompletionDocumentationTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelSmartCompletionDocumentationTestIT.java
@@ -20,7 +20,6 @@ import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiLiteralExpression;
 import com.intellij.psi.PsiManager;
-import com.intellij.psi.PsiReference;
 import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
 
 /**
@@ -58,6 +57,22 @@ public class CamelSmartCompletionDocumentationTestIT extends CamelLightCodeInsig
         assertEquals(componentName, de.getComponentName());
         assertEquals("delete", de.getText());
         assertEquals("delete", de.getEndpointOption());
+    }
+
+    public void testXMLQuickDocCaretOnAmpersand() throws Exception {
+        myFixture.configureByFile("XmlCamelRouteQuickDocCaretOnAmpTestData.xml");
+        PsiElement element = getElementAtCaret();
+        assertNotNull(element);
+        CamelDocumentationProvider camelDocumentationProvider = new CamelDocumentationProvider();
+        assertEquals(element.getParent(), camelDocumentationProvider.getCustomDocumentationElement(myFixture.getEditor(), myFixture.getFile(), element));
+    }
+
+    public void testXMLQuickDocCaretAtTheEndOfTheRoute() throws Exception {
+        myFixture.configureByFile("XmlCamelRouteQuickDocCaretAtTheEndTestData.xml");
+        PsiElement element = getElementAtCaret();
+        assertNotNull(element);
+        CamelDocumentationProvider camelDocumentationProvider = new CamelDocumentationProvider();
+        assertEquals(element.getParent(), camelDocumentationProvider.getCustomDocumentationElement(myFixture.getEditor(), myFixture.getFile(), element));
     }
 
 }

--- a/camel-idea-plugin/src/test/resources/testData/documentation/XmlCamelRouteQuickDocCaretAtTheEndTestData.xml
+++ b/camel-idea-plugin/src/test/resources/testData/documentation/XmlCamelRouteQuickDocCaretAtTheEndTestData.xml
@@ -1,0 +1,4 @@
+<route>
+    <from uri="file:inbox?delete=true&amp;fileExist=Append<caret>"/>
+    <to uri="file:outbox?flatten=true"/>
+</route>

--- a/camel-idea-plugin/src/test/resources/testData/documentation/XmlCamelRouteQuickDocCaretOnAmpTestData.xml
+++ b/camel-idea-plugin/src/test/resources/testData/documentation/XmlCamelRouteQuickDocCaretOnAmpTestData.xml
@@ -1,0 +1,4 @@
+<route>
+    <from uri="file:inbox?delete=true&a<caret>mp;fileExist=Append"/>
+    <to uri="file:outbox?flatten=true"/>
+</route>


### PR DESCRIPTION
Added unit test for documentation popup for routes that contains &amp;

@davsclaus , @fharms I've noticed in the tests many occurrences of

`// this does not work with <caret> in the source code`
 `// PsiElement element = myFixture.getElementAtCaret();`

To fix that i've added the `CamelLightCodeInsightFixtureTestCaseIT.getElementAtCaret` method. Let me know if that fixes the issue.