### PR TITLE
#240 Added gutter route navigation from/to Java/XML

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/gutter/GutterPsiElementListCellRenderer.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/gutter/GutterPsiElementListCellRenderer.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.idea.gutter;
+
+import javax.swing.*;
+
+import com.intellij.ide.util.PsiElementListCellRenderer;
+import com.intellij.openapi.util.Iconable;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLiteralExpression;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A gutter navigation list renderer to customize the display of the related Camel routes.
+ */
+class GutterPsiElementListCellRenderer extends PsiElementListCellRenderer {
+    @Override
+    public String getElementText(PsiElement element) {
+        if (element instanceof PsiLiteralExpression) {
+            return ((PsiLiteralExpression) element).getValue().toString();
+        }
+        return element.getText();
+    }
+
+    @Nullable
+    @Override
+    protected String getContainerText(PsiElement element, String s) {
+        return element.getContainingFile().getVirtualFile().getName();
+    }
+
+    @Override
+    protected int getIconFlags() {
+        return Iconable.ICON_FLAG_VISIBILITY;
+    }
+
+    @Override
+    protected Icon getIcon(PsiElement psiElement) {
+        return psiElement.getContainingFile().getIcon(Iconable.ICON_FLAG_VISIBILITY);
+    }
+}

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/GutterTestUtil.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/GutterTestUtil.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.idea.gutter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.codeInsight.daemon.LineMarkerProvider;
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo;
+import com.intellij.codeInsight.daemon.impl.LineMarkersPass;
+import com.intellij.lang.java.JavaLanguage;
+import com.intellij.navigation.GotoRelatedItem;
+
+
+/**
+ * Utility class to test the gutter navigation.
+ */
+final class GutterTestUtil {
+
+    private GutterTestUtil() {
+        //empty
+    }
+
+    static List<GotoRelatedItem> getGutterNavigationDestinationElements(LineMarkerInfo.LineMarkerGutterIconRenderer gutter) {
+        LineMarkerProvider lineMarkerProvider1 = LineMarkersPass.getMarkerProviders(JavaLanguage.INSTANCE, gutter
+                .getLineMarkerInfo()
+                .getElement().getProject())
+                .stream()
+                .filter(lineMarkerProvider -> lineMarkerProvider instanceof CamelRouteLineMarkerProvider).findAny()
+                .get();
+        List<RelatedItemLineMarkerInfo> result = new ArrayList<>();
+        ((CamelRouteLineMarkerProvider) lineMarkerProvider1).collectNavigationMarkers(gutter.getLineMarkerInfo().getElement(), result);
+        return (List<GotoRelatedItem>) result.get(0).createGotoRelatedItems();
+    }
+}

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/JavaCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/JavaCamelRouteLineMarkerProviderTestIT.java
@@ -18,31 +18,61 @@ package org.apache.camel.idea.gutter;
 
 import java.util.List;
 import javax.swing.*;
-
 import com.intellij.codeInsight.daemon.GutterMark;
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.navigation.GotoRelatedItem;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.psi.PsiLiteralExpression;
+import com.intellij.psi.impl.source.tree.java.PsiMethodCallExpressionImpl;
 import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import org.apache.camel.idea.service.CamelPreferenceService;
 
+import static org.apache.camel.idea.gutter.GutterTestUtil.getGutterNavigationDestinationElements;
+
 /**
- * Testing the Camel icon is shown in the gutter where a Camel route starts in Java DSL
+ * Testing the Camel icon is shown in the gutter where a Camel route starts in Java DSL and the route navigation
  */
 public class JavaCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
     public void testCamelGutter() {
         myFixture.configureByFiles("JavaCamelRouteLineMarkerProviderTestData.java");
-        List<GutterMark> gutters = myFixture.findGuttersAtCaret();
+        List<GutterMark> gutters = myFixture.findAllGutters();
         assertNotNull(gutters);
 
-        assertEquals(1, gutters.size());
-        GutterMark gutter = gutters.get(0);
+        //remove first element since it is navigate to super implementation gutter icon
+        gutters.remove(0);
 
-        assertEquals("<html>Camel route</html>", gutter.getTooltipText());
+        assertEquals("Should contain 2 Camel gutters", 2, gutters.size());
 
         Icon defaultIcon = ServiceManager.getService(CamelPreferenceService.class).getCamelIcon();
-        Icon icon = gutter.getIcon();
+        gutters.forEach(gutterMark -> {
+            assertSame("Gutter should have the Camel icon", defaultIcon, gutterMark.getIcon());
+            assertEquals("Camel route", gutterMark.getTooltipText());
+        });
 
-        assertSame(defaultIcon, icon);
+        LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(0);
+
+        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiLiteralExpression);
+        assertEquals("The navigation start element doesn't match", "file:inbox",
+                ((PsiLiteralExpression) firstGutter.getLineMarkerInfo().getElement()).getValue());
+
+
+        List<GotoRelatedItem> firstGutterTargets = getGutterNavigationDestinationElements(firstGutter);
+        assertEquals("Navigation should have one target", 1, firstGutterTargets.size());
+        assertEquals("The navigation target element doesn't match", "from(\"file:outbox\")",
+                ((PsiMethodCallExpressionImpl) firstGutterTargets.get(0).getElement().getParent().getParent()).getMethodExpression().getQualifierExpression().getText());
+
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(1);
+
+        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof PsiLiteralExpression);
+        assertEquals("The navigation start element doesn't match", "file:outbox",
+                ((PsiLiteralExpression) secondGutter.getLineMarkerInfo().getElement()).getValue());
+
+        List<GotoRelatedItem> secondGutterTargets = getGutterNavigationDestinationElements(secondGutter);
+        assertEquals("Navigation should have one target", 1, secondGutterTargets.size());
+        assertEquals("The navigation target element doesn't match", "from(\"file:inbox\")",
+                ((PsiMethodCallExpressionImpl) secondGutterTargets.get(0).getElement().getParent().getParent()).getMethodExpression().getQualifierExpression().getText());
     }
 
 }

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/MultiLanguageCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/MultiLanguageCamelRouteLineMarkerProviderTestIT.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.idea.gutter;
+
+import java.util.List;
+
+import com.intellij.codeInsight.daemon.GutterMark;
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.navigation.GotoRelatedItem;
+import com.intellij.psi.PsiLiteralExpression;
+import com.intellij.psi.impl.source.tree.java.PsiMethodCallExpressionImpl;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.psi.xml.XmlTag;
+import com.intellij.psi.xml.XmlToken;
+import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
+
+/**
+ * Testing the Camel icon is shown in the gutter where a Camel route starts in XML DSL and the route navigation
+ */
+public class MultiLanguageCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    public void testCamelGutterForJavaAndXMLRoutes() {
+        myFixture.configureByFiles("XmlCamelRouteLineMarkerProviderTestData.xml", "JavaCamelRouteLineMarkerProviderTestData.java");
+        List<GutterMark> javaGutters = myFixture.findAllGutters("JavaCamelRouteLineMarkerProviderTestData.java");
+        assertNotNull(javaGutters);
+
+        List<GutterMark> xmlGutters = myFixture.findAllGutters("XmlCamelRouteLineMarkerProviderTestData.xml");
+        assertNotNull(xmlGutters);
+
+        //remove first element since it is navigate to super implementation gutter icon
+        javaGutters.remove(0);
+
+        assertEquals("Should contain 2 Java Camel gutters", 2, javaGutters.size());
+        assertEquals("Should contain 2 XML Camel gutters", 2, xmlGutters.size());
+
+        //from Java to XML
+        LineMarkerInfo.LineMarkerGutterIconRenderer firstJavaGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) javaGutters.get(0);
+        assertTrue(firstJavaGutter.getLineMarkerInfo().getElement() instanceof PsiLiteralExpression);
+        assertEquals("The navigation start element doesn't match", "file:inbox",
+                ((PsiLiteralExpression) firstJavaGutter.getLineMarkerInfo().getElement()).getValue());
+
+
+        List<GotoRelatedItem> firstJavaGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstJavaGutter);
+        assertEquals("Navigation should have two targets", 2, firstJavaGutterTargets.size());
+        assertEquals("The navigation target XML tag name doesn't match", "to",
+                PsiTreeUtil.getParentOfType(firstJavaGutterTargets.get(0).getElement(), XmlTag.class).getLocalName());
+        assertEquals("The navigation Java target element doesn't match", "from(\"file:outbox\")",
+                ((PsiMethodCallExpressionImpl) firstJavaGutterTargets.get(1).getElement().getParent().getParent()).getMethodExpression().getQualifierExpression().getText());
+
+        //from XML to Java
+        LineMarkerInfo.LineMarkerGutterIconRenderer firstXmlGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) xmlGutters.get(0);
+        assertTrue(firstXmlGutter.getLineMarkerInfo().getElement() instanceof XmlToken);
+        assertEquals("The navigation start element doesn't match", "file:inbox",
+                ((PsiLiteralExpression) firstJavaGutter.getLineMarkerInfo().getElement()).getValue());
+
+
+        List<GotoRelatedItem> firstXmlGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstXmlGutter);
+        assertEquals("Navigation should have two targets", 2, firstXmlGutterTargets.size());
+        assertEquals("The navigation target XML tag name doesn't match", "to",
+                PsiTreeUtil.getParentOfType(firstXmlGutterTargets.get(0).getElement(), XmlTag.class).getLocalName());
+        assertEquals("The navigation Java target element doesn't match", "from(\"file:outbox\")",
+                ((PsiMethodCallExpressionImpl) firstXmlGutterTargets.get(1).getElement().getParent().getParent()).getMethodExpression().getQualifierExpression().getText());
+    }
+
+}

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/XmlCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/XmlCamelRouteLineMarkerProviderTestIT.java
@@ -18,31 +18,59 @@ package org.apache.camel.idea.gutter;
 
 import java.util.List;
 import javax.swing.*;
-
 import com.intellij.codeInsight.daemon.GutterMark;
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.navigation.GotoRelatedItem;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.psi.xml.XmlTag;
+import com.intellij.psi.xml.XmlToken;
 import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import org.apache.camel.idea.service.CamelPreferenceService;
 
+import static org.apache.camel.idea.gutter.GutterTestUtil.getGutterNavigationDestinationElements;
+
 /**
- * Testing the Camel icon is shown in the gutter where a Camel route starts in XML DSL
+ * Testing the Camel icon is shown in the gutter where a Camel route starts in XML DSL and the route navigation
  */
 public class XmlCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
     public void testCamelGutter() {
         myFixture.configureByFiles("XmlCamelRouteLineMarkerProviderTestData.xml");
-        List<GutterMark> gutters = myFixture.findGuttersAtCaret();
+        List<GutterMark> gutters = myFixture.findAllGutters();
         assertNotNull(gutters);
 
-        assertEquals(1, gutters.size());
-        GutterMark gutter = gutters.get(0);
-
-        assertEquals("Camel route", gutter.getTooltipText());
+        assertEquals("Should contain 2 Camel gutters", 2, gutters.size());
 
         Icon defaultIcon = ServiceManager.getService(CamelPreferenceService.class).getCamelIcon();
-        Icon icon = gutter.getIcon();
+        gutters.forEach(gutterMark -> {
+            assertSame("Gutter should have the Camel icon", defaultIcon, gutterMark.getIcon());
+            assertEquals("Camel route", gutterMark.getTooltipText());
+        });
 
-        assertSame(defaultIcon, icon);
+        LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(0);
+
+        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof XmlToken);
+        assertEquals("The navigation start element doesn't match", "file:inbox",
+                PsiTreeUtil.getParentOfType(firstGutter.getLineMarkerInfo().getElement(), XmlTag.class).getAttribute("uri").getValue());
+
+        List<GotoRelatedItem> firstGutterTargets = getGutterNavigationDestinationElements(firstGutter);
+        assertEquals("Navigation should have one target", 1, firstGutterTargets.size());
+        assertEquals("The navigation target route doesn't match", "file:inbox", firstGutterTargets.get(0).getElement().getText());
+        assertEquals("The navigation target tag name doesn't match", "to",
+                PsiTreeUtil.getParentOfType(firstGutterTargets.get(0).getElement(), XmlTag.class).getLocalName());
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(1);
+
+        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof XmlToken);
+        assertEquals("The navigation start element doesn't match", "file:outbox",
+                PsiTreeUtil.getParentOfType(secondGutter.getLineMarkerInfo().getElement(), XmlTag.class).getAttribute("uri").getValue());
+
+        List<GotoRelatedItem> secondGutterTargets = getGutterNavigationDestinationElements(secondGutter);
+        assertEquals("Navigation should have one target", 1, secondGutterTargets.size());
+        assertEquals("The navigation target route doesn't match", "file:outbox", secondGutterTargets.get(0).getElement().getText());
+        assertEquals("The navigation target tag name doesn't match", "to",
+                PsiTreeUtil.getParentOfType(secondGutterTargets.get(0).getElement(), XmlTag.class).getLocalName());
     }
 
 }

--- a/camel-idea-plugin/src/test/resources/testData/JavaCamelRouteLineMarkerProviderTestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/JavaCamelRouteLineMarkerProviderTestData.java
@@ -1,38 +1,29 @@
-/**
+package org.apache.camel.idea.gutter; /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
 
-public final class JavaCamelRouteLineMarkerProviderTestData {
-
-    private JavaAddEndpointIntentionTestData() { }
-
-    public static void main(String[] args) {
-        Main main = new Main();
-        main.addRouteBuilder(new MyRouteBuilder());
-        main.run(args);
+public class JavaCamelRouteLineMarkerProviderTestData extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("file:inbox")
+                .to("file:outbox");
+        from("file:outbox")
+                .to("file:inbox");
     }
-
-    public static class MyRouteBuilder extends RouteBuilder {
-        @Override
-        public void configure() throws Exception {
-            from("file:inbox<caret>")
-                .to("file:outbox")
-        }
-    }
-
 }

--- a/camel-idea-plugin/src/test/resources/testData/XmlCamelRouteLineMarkerProviderTestData.xml
+++ b/camel-idea-plugin/src/test/resources/testData/XmlCamelRouteLineMarkerProviderTestData.xml
@@ -17,7 +17,9 @@
 -->
 <routes>
   <route>
-    <<caret>from uri="file:inbox"/>
-    <to uroi="file:outbox"/>
+    <from uri="file:inbox"/>
+    <to uri="file:outbox"/>
+    <from uri="file:outbox"/>
+    <to uri="file:inbox"/>
   </route>
 </routes>


### PR DESCRIPTION
First version of the navigation that suports Java literals and XML only. The issue #242 is still not solved so i did a workaround to filter out everything that is not a literal for Java.