### PR TITLE
Multiline completion support

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/AbstractCamelAnnotator.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/AbstractCamelAnnotator.java
@@ -48,7 +48,7 @@ abstract class AbstractCamelAnnotator implements Annotator {
         if (ServiceManager.getService(element.getProject(), CamelService.class).isCamelPresent() && isEnabled()) {
             boolean accept = accept(element);
             if (accept) {
-                String text = IdeaUtils.extractTextFromElement(element, false);
+                String text = IdeaUtils.extractTextFromElement(element, false, false);
                 if (!StringUtils.isEmpty(text)) {
                     validateText(element, holder, text);
                 }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/CamelSmartCompletionEndpointOptions.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/CamelSmartCompletionEndpointOptions.java
@@ -51,22 +51,25 @@ public final class CamelSmartCompletionEndpointOptions {
         // static class
     }
 
-    public static List<LookupElement> addSmartCompletionSuggestionsQueryParameters(String val, ComponentModel component,
-                                                                                   Map<String, String> existing, boolean xmlMode, PsiElement element, Editor editor, String suffix) {
+    public static List<LookupElement> addSmartCompletionSuggestionsQueryParameters(String[] query, ComponentModel component,
+                                                                                   Map<String, String> existing, boolean xmlMode, PsiElement element, Editor editor) {
         List<LookupElement> answer = new ArrayList<>();
 
         boolean consumerOnly = isConsumerEndpoint(element);
         boolean producerOnly = isProducerEndpoint(element);
 
+        String concatQuery = query[0];
+        String suffix = query[1];
+        String queryAtPosition = query[2];
+
         if (xmlMode) {
-            val = val.replace("&amp;", "&");
+            queryAtPosition = queryAtPosition.replace("&amp;", "&");
         }
 
         List<EndpointOptionModel> options = component.getEndpointOptions();
         // sort the options A..Z which is easier to users to understand
         options.sort((o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName()));
-
-        val = removeUnknownOption(val, existing, element);
+        queryAtPosition = removeUnknownOption(queryAtPosition, existing, element);
 
         for (EndpointOptionModel option : options) {
 
@@ -91,16 +94,15 @@ public final class CamelSmartCompletionEndpointOptions {
 
                     // the lookup should prepare for the new option
                     String lookup;
-                    val = val.replace("val", "");
-                    if (!val.contains("?")) {
+                    if (!concatQuery.contains("?")) {
                         // none existing options so we need to start with a ? mark
-                        lookup = val + "?" + key;
+                        lookup = queryAtPosition + "?" + key;
                     } else {
-                        if (!val.endsWith("&") && !val.endsWith("?")) {
-                            lookup = val + "&" + key;
+                        if (!queryAtPosition.endsWith("&") && !queryAtPosition.endsWith("?")) {
+                            lookup = queryAtPosition + "&" + key;
                         } else {
                             // there is already either an ending ? or &
-                            lookup = val + key;
+                            lookup = queryAtPosition + key;
                         }
                     }
                     if (xmlMode) {
@@ -234,7 +236,7 @@ public final class CamelSmartCompletionEndpointOptions {
             //check if the option is known option
             final String optionToRemove = existing.get(searchStr);
             if (optionToRemove == null || optionToRemove.isEmpty()) {
-                val = val.replace(strToRemove[0], "");
+                val = val.replace(searchStr, "");
             }
         }
         return val;

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/inspection/AbstractCamelInspection.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/inspection/AbstractCamelInspection.java
@@ -92,7 +92,7 @@ public abstract class AbstractCamelInspection extends LocalInspectionTool {
                 @Override
                 public void visitElement(PsiElement element) {
                     if (accept(element)) {
-                        String text = IdeaUtils.extractTextFromElement(element, false);
+                        String text = IdeaUtils.extractTextFromElement(element, false, false);
                         if (!StringUtils.isEmpty(text)) {
                             validateText(element, holder, text, isOnTheFly);
                         }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/intention/CamelAddEndpointIntention.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/intention/CamelAddEndpointIntention.java
@@ -118,7 +118,7 @@ public class CamelAddEndpointIntention extends PsiElementBaseIntentionAction imp
                 }
             } else {
                 // should be a literal element and therefore dont fallback to generic
-                text = extractTextFromElement(element, false);
+                text = extractTextFromElement(element, false, false);
             }
 
             return text != null && text.trim().isEmpty();

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaEndpointSmartCompletionTestIT.java
@@ -80,9 +80,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", getJavaInTheMiddleOfResolvedOptionsData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertThat(strings, Matchers.not(Matchers.contains("timer:trigger?repeatCount=10")));
-        assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&fixedRate"));
-        assertTrue("There is less options", strings.size() == 1);
+        assertTrue("Expect 0 options", strings.size() == 0);
     }
 
     private String getJavaAfterAmpOptionsTestData() {
@@ -167,6 +165,111 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         assertThat(strings, Matchers.contains("timer:trigger?period"));
         myFixture.type('\n');
         javaInsertAfterQuestionMarkTestData = javaInsertAfterQuestionMarkTestData.replace("<caret>", "iod=");
+        myFixture.checkResult(javaInsertAfterQuestionMarkTestData);
+    }
+
+    private String getJavaMultilineTestData() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger?repeatCount=10&\" +\n"
+            + "                \"fixedRate=false\"+ \n"
+            + "                \"&daemon=false\" + \n"
+            + "                \"&period=10<caret>\");\n"
+            + "        }\n"
+            + "    }";
+    }
+    public void testJavaMultilineTestData() {
+        myFixture.configureByText("CamelRoute.java", getJavaMultilineTestData());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals("There is many options", 8, strings.size());
+        assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
+            "timer:trigger?repeatCount=10&",
+            "&fixedRate=false",
+            "&daemon=false",
+            "&period=10")));
+        myFixture.type('\n');
+        String javaInsertAfterQuestionMarkTestData = getJavaMultilineTestData().replace("<caret>", "&bridgeErrorHandler=");
+        myFixture.checkResult(javaInsertAfterQuestionMarkTestData);
+    }
+
+    private String getJavaMultilineTest2Data() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger?repeatCount=10\"\n"
+            + "                + \"&fixedRate=false<caret>\"\n"
+            + "                + \"&daemon=false\" \n"
+            + "                + \"&period=10\");\n"
+            + "        }\n"
+            + "    }";
+    }
+    public void testJavaMultilineTest2Data() {
+        myFixture.configureByText("CamelRoute.java", getJavaMultilineTest2Data());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals("There is many options", 8, strings.size());
+        assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
+            "timer:trigger?repeatCount=10&",
+            "&fixedRate=false",
+            "&daemon=false",
+            "&period=10")));
+        myFixture.type('\n');
+        String javaInsertAfterQuestionMarkTestData = getJavaMultilineTest2Data().replace("<caret>", "&bridgeErrorHandler=");
+        myFixture.checkResult(javaInsertAfterQuestionMarkTestData);
+    }
+
+    private String getJavaMultilineTest3Data() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger?repeatCount=10\"+\n"
+            + "                 \"&fixedRate=false\"+\n"
+            + "                 \"&daemon=false\" \n"
+            + "                + \"&period=10&<caret>\");\n"
+            + "        }\n"
+            + "    }";
+    }
+    public void testJavaMultilineTest3Data() {
+        myFixture.configureByText("CamelRoute.java", getJavaMultilineTest3Data());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals("There is many options", 8, strings.size());
+        assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
+            "timer:trigger?repeatCount=10&",
+            "&fixedRate=false",
+            "&daemon=false",
+            "&period=10")));
+        myFixture.type('\n');
+        String javaInsertAfterQuestionMarkTestData = getJavaMultilineTest3Data().replace("<caret>", "bridgeErrorHandler=");
+        myFixture.checkResult(javaInsertAfterQuestionMarkTestData);
+    }
+
+    private String getJavaMultilineInFixSearchData() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger?repeatCount=10\"+\n"
+            + "                 \"&ex<caret>fixedRate=false\"+\n"
+            + "                 \"&daemon=false\" \n"
+            + "                + \"&period=10\");\n"
+            + "        }\n"
+            + "    }";
+    }
+    public void testJavaMultilineInFixSearchData() {
+        myFixture.configureByText("CamelRoute.java", getJavaMultilineInFixSearchData());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals("There is many options", 2, strings.size());
+        assertThat(strings, Matchers.containsInAnyOrder("&exceptionHandler", "&exchangePattern"));
+        assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
+            "timer:trigger?repeatCount=10&",
+            "&fixedRate=false",
+            "&daemon=false",
+            "&period=10")));
+        myFixture.type('\n');
+        String javaInsertAfterQuestionMarkTestData = getJavaMultilineInFixSearchData().replace("<caret>", "ceptionHandler=");
         myFixture.checkResult(javaInsertAfterQuestionMarkTestData);
     }
 

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/PropertyEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/PropertyEndpointSmartCompletionTestIT.java
@@ -98,12 +98,7 @@ public class PropertyEndpointSmartCompletionTestIT extends CamelLightCodeInsight
         myFixture.configureByText("TestData.properties", getInTheMiddleOfResolvedOptionsData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertThat(strings, Matchers.not(Matchers.contains("timer:trigger?repeatCount=10")));
-        assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&fixedRate"));
-        assertTrue("There is less options", strings.size() == 1);
-        myFixture.type('\n');
-        String result = getInTheMiddleOfResolvedOptionsData().replace("<caret>", "Rate=");
-        myFixture.checkResult(result);
+        assertTrue("Expect 0 options", strings.size() == 0);
     }
 
     private String getInTheMiddleUnresolvedOptionsTestData() {

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/XmlEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/XmlEndpointSmartCompletionTestIT.java
@@ -21,8 +21,11 @@ import java.util.List;
 
 import com.intellij.codeInsight.completion.CompletionType;
 import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
-import org.hamcrest.Matchers;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -43,8 +46,8 @@ public class XmlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtu
         myFixture.configureByFiles("CompleteXmlEndpointProducerTestData.xml");
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertFalse(strings.containsAll(Arrays.asList("file:outbox?autoCreate", "file:outbox?include", "file:outbox?delay", "file:outbox?delete")));
-        assertTrue(strings.containsAll(Arrays.asList("file:outbox?fileExist", "file:outbox?forceWrites")));
+        assertThat(strings, not(contains(Arrays.asList("file:outbox?autoCreate", "file:outbox?include", "file:outbox?delay", "file:outbox?delete"))));
+        assertThat(strings, hasItems("file:outbox?fileExist", "file:outbox?forceWrites"));
         assertTrue("There is less options", strings.size() < 30);
     }
 
@@ -59,11 +62,11 @@ public class XmlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtu
 
     public void testXmlInsertAfterQuestionMarkTestData() {
         String insertAfterQuestionMarkTestData = getXmlInsertAfterQuestionMarkTestData();
-        myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", insertAfterQuestionMarkTestData);
+        myFixture.configureByText("JavaCaretInMiddleOptionsTestData.xml", insertAfterQuestionMarkTestData);
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
         assertTrue("There is many options", strings.size() == 1);
-        assertThat(strings, Matchers.contains("timer:trigger?period"));
+        assertThat(strings, contains("timer:trigger?period"));
         myFixture.type('\n');
         insertAfterQuestionMarkTestData = insertAfterQuestionMarkTestData.replace("<caret>", "iod=");
         myFixture.checkResult(insertAfterQuestionMarkTestData);
@@ -114,18 +117,18 @@ public class XmlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtu
         myFixture.configureByText("XmlCaretInMiddleOptionsTestData.xml", getXmlfterAmpOptionsTestData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertThat(strings, Matchers.not(Matchers.contains("timer:trigger?repeatCount=10")));
-        assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&amp;bridgeErrorHandler",
-            "timer:trigger?repeatCount=10&amp;daemon",
-            "timer:trigger?repeatCount=10&amp;delay",
-            "timer:trigger?repeatCount=10&amp;exceptionHandler",
-            "timer:trigger?repeatCount=10&amp;exchangePattern",
-            "timer:trigger?repeatCount=10&amp;fixedRate",
-            "timer:trigger?repeatCount=10&amp;pattern",
-            "timer:trigger?repeatCount=10&amp;period",
-            "timer:trigger?repeatCount=10&amp;synchronous",
-            "timer:trigger?repeatCount=10&amp;time",
-            "timer:trigger?repeatCount=10&amp;timer"));
+        assertThat(strings, not(contains("timer:trigger?repeatCount=10")));
+        assertThat(strings, contains("&amp;bridgeErrorHandler",
+            "&amp;daemon",
+            "&amp;delay",
+            "&amp;exceptionHandler",
+            "&amp;exchangePattern",
+            "&amp;fixedRate",
+            "&amp;pattern",
+            "&amp;period",
+            "&amp;synchronous",
+            "&amp;time",
+            "&amp;timer"));
         assertTrue("There is less options", strings.size() < 13);
     }
 
@@ -142,9 +145,7 @@ public class XmlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtu
         myFixture.configureByText("XmlCaretInMiddleOptionsTestData.xml", getXmlInTheMiddleOfResolvedOptionsData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertThat(strings, Matchers.not(Matchers.contains("timer:trigger?repeatCount=10")));
-        assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&amp;fixedRate"));
-        assertTrue("There is less options", strings.size() == 1);
+        assertTrue("There is less options", strings.size() == 0);
     }
 
     private String getXmlInTheMiddleUnresolvedOptionsTestData() {
@@ -160,9 +161,8 @@ public class XmlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtu
         myFixture.configureByText("XmlCaretInMiddleOptionsTestData.xml", getXmlInTheMiddleUnresolvedOptionsTestData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertThat(strings, Matchers.not(Matchers.contains("timer:trigger?repeatCount=10")));
-        assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&amp;exceptionHandler",
-            "timer:trigger?repeatCount=10&amp;exchangePattern"));
+        assertThat(strings, not(contains("timer:trigger?repeatCount=10")));
+        assertThat(strings, contains("&amp;exceptionHandler", "&amp;exchangePattern"));
         assertTrue("There is less options", strings.size() == 2);
         myFixture.type('\n');
         String result = getXmlInTheMiddleUnresolvedOptionsTestData().replace("<caret>", "ceptionHandler=");
@@ -186,5 +186,106 @@ public class XmlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtu
         myFixture.type('\n');
         String result = getXmlAfterValueWithOutAmpTestData().replace("<caret>", "&amp;bridgeErrorHandler=");
         myFixture.checkResult(result);
+    }
+
+    private String getXmlMultilineTestData() {
+        return "<routes>\n"
+            + "  <route>\n"
+            + "    <from uri=\"timer:trigger?repeatCount=10\n"
+            + "         &amp;fixedRate=false\n"
+            + "         &amp;daemon=false\n"
+            + "         &amp;period=10<caret>\"/>"
+            + "    <to uri=\"file:outbox?delete=true&amp;fileExist=Append\"/>\n"
+            + "  </route>\n"
+            + "</routes>";
+    }
+    public void testXmlMultilineTestData() {
+        myFixture.configureByText("CamelRoute.xml", getXmlMultilineTestData());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals("There is many options", 8, strings.size());
+        assertThat(strings, not(containsInAnyOrder(
+            "timer:trigger?repeatCount=10&",
+            "&fixedRate=false",
+            "&daemon=false",
+            "&period=10")));
+        myFixture.type('\n');
+        String xmlInsertAfterQuestionMarkTestData = getXmlMultilineTestData().replace("<caret>", "&amp;bridgeErrorHandler=");
+        myFixture.checkResult(xmlInsertAfterQuestionMarkTestData);
+    }
+
+    private String getXmlMultilineTest2Data() {
+        return "<routes>\n"
+            + "  <route>\n"
+            + "    <from uri=\"timer:trigger?repeatCount=10\n"
+            + "         &amp;fixedRate=false<caret>\n"
+            + "         &amp;daemon=false\n"
+            + "         &amp;period=10\"/>"
+            + "    <to uri=\"file:outbox?delete=true&amp;fileExist=Append\"/>\n"
+            + "  </route>\n"
+            + "</routes>";
+    }
+    public void testXmlMultilineTest2Data() {
+        myFixture.configureByText("CamelRoute.xml", getXmlMultilineTest2Data());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals("There is many options", 8, strings.size());
+        assertThat(strings, not(containsInAnyOrder(
+            "timer:trigger?repeatCount=10",
+            "&amp;fixedRate=false",
+            "&amp;daemon=false",
+            "&amp;period=10")));
+        myFixture.type('\n');
+        String xmlInsertAfterQuestionMarkTestData = getXmlMultilineTest2Data().replace("<caret>", "&amp;bridgeErrorHandler=");
+        myFixture.checkResult(xmlInsertAfterQuestionMarkTestData);
+    }
+
+    private String getXmlMultilineTest3Data() {
+        return "<routes>\n"
+            + "  <route>\n"
+            + "    <from uri=\"timer:trigger?repeatCount=10\n"
+            + "         &amp;fixedRate=false\n"
+            + "         &amp;daemon=false\n"
+            + "         &amp;period=10<caret>\"/>"
+            + "    <to uri=\"file:outbox?delete=true&amp;fileExist=Append\"/>\n"
+            + "  </route>\n"
+            + "</routes>";
+    }
+    public void testXmlMultilineTest3Data() {
+        myFixture.configureByText("CamelRoute.xml", getXmlMultilineTest3Data());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals("There is many options", 8, strings.size());
+        assertThat(strings, not(containsInAnyOrder(
+            "timer:trigger?repeatCount=10&amp;",
+            "&amp;fixedRate=false",
+            "&amp;daemon=false",
+            "&amp;period=10")));
+        myFixture.type('\n');
+        String xmlInsertAfterQuestionMarkTestData = getXmlMultilineTest3Data().replace("<caret>", "&amp;bridgeErrorHandler=");
+        myFixture.checkResult(xmlInsertAfterQuestionMarkTestData);
+    }
+
+    private String getXmlMultilineInFixSearchData() {
+        return "<routes>\n"
+            + "  <route>\n"
+            + "    <from uri=\"timer:trigger?repeatCount=10\n"
+            + "         &amp;ex<caret>fixedRate=false\n"
+            + "         &amp;daemon=false\n"
+            + "         &amp;period=10\"/>"
+            + "    <to uri=\"file:outbox?delete=true&amp;fileExist=Append\"/>\n"
+            + "  </route>\n"
+            + "</routes>";
+
+    }
+    public void testJavaMultilineInFixSearchData() {
+        myFixture.configureByText("CamelRoute.xml", getXmlMultilineInFixSearchData());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals("There is many options", 2, strings.size());
+        assertThat(strings, containsInAnyOrder("&amp;exceptionHandler", "&amp;exchangePattern"));
+        myFixture.type('\n');
+        String xmlInsertAfterQuestionMarkTestData = getXmlMultilineInFixSearchData().replace("<caret>", "ceptionHandler=");
+        myFixture.checkResult(xmlInsertAfterQuestionMarkTestData);
     }
 }


### PR DESCRIPTION
This is the first batch of multi line support for code completion, if you split endpoint uri over multiple lines the code completion will still work
```java
  from("timer:trigger?repeatCount=10" +
                "&fixedRate=false&bridgeErrorHandler=false" +
                "&daemon=false" +
                "&period=10&delay=1000")
```

The validation is not tested in depth, but a quick test shows it worked in the cases I tried. 
Since this required changes in some of the shared methods I want to push this to avoid too many conflicts. The code is in a good shape and multiple tests cases is added, but after it's merged I will properly use some time to clean it up a bit and test validation more