### PR TITLE
fix for #277: Scala routes using "==>" have no gutter icon

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
@@ -16,32 +16,6 @@
  */
 package org.apache.camel.idea.service;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarInputStream;
-import java.util.stream.Collectors;
-import javax.swing.*;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.Disposable;
@@ -57,6 +31,20 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.idea.util.IdeaUtils;
 import org.jetbrains.annotations.NotNull;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.swing.*;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.*;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.stream.Collectors;
 
 import static org.apache.camel.catalog.CatalogHelper.loadText;
 import static org.apache.camel.idea.completion.CamelContributor.CAMEL_NOTIFICATION_GROUP;
@@ -178,7 +166,7 @@ public class CamelService implements Disposable {
                         continue;
                     }
                     int startIdx = 0;
-                    if (split[0].equalsIgnoreCase("maven") || split[0].equalsIgnoreCase("gradle")) {
+                    if (split[0].equalsIgnoreCase("maven") || split[0].equalsIgnoreCase("gradle") || split[0].equalsIgnoreCase("sbt")) {
                         startIdx = 1;
                     }
                     String groupId = split[startIdx++].trim();

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/CamelIdeaUtils.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/CamelIdeaUtils.java
@@ -16,30 +16,19 @@
  */
 package org.apache.camel.idea.util;
 
-import java.util.Arrays;
-
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiAnnotation;
-import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiClassType;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiExpression;
-import com.intellij.psi.PsiExpressionList;
-import com.intellij.psi.PsiMethod;
-import com.intellij.psi.PsiMethodCallExpression;
-import com.intellij.psi.PsiReferenceExpression;
+import com.intellij.psi.*;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.xml.XmlTag;
 import org.apache.camel.idea.service.CamelCatalogService;
 
-import static org.apache.camel.idea.util.IdeaUtils.isElementFromAnnotation;
-import static org.apache.camel.idea.util.IdeaUtils.isElementFromConstructor;
-import static org.apache.camel.idea.util.IdeaUtils.isElementFromSetterProperty;
-import static org.apache.camel.idea.util.IdeaUtils.isFromFileType;
+import java.util.Arrays;
+
+import static org.apache.camel.idea.util.IdeaUtils.*;
 
 /**
  * Utility methods to work with Camel related {@link com.intellij.psi.PsiElement} elements.
@@ -103,7 +92,13 @@ public final class CamelIdeaUtils {
         if (element instanceof LeafPsiElement) {
             IElementType type = ((LeafPsiElement) element).getElementType();
             if (type.getLanguage().isKindOf("Scala")) {
-                return IdeaUtils.isFromScalaMethod(element, ROUTE_START);
+                try {
+                    // TODO needs cleaning and remove try...catch (plus does not work)
+                    PsiElement infixExpression = element.getParent().getParent();
+                    return infixExpression.getChildren()[1].getText().equals("==>");
+                } catch (NullPointerException | ArrayIndexOutOfBoundsException ignored){
+
+                }
             }
         }
 


### PR DESCRIPTION
I have tested it with my scala dsl demos and so far so good. 

It does not support routes like using an implicit conversion without the arrow method. Most likely there is a way to obtain implicit in scope to see if the string gets converted using the implicit def `stringToRoute`. I'll can a look into that later.