### PR TITLE
Multiline validation support

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/CamelEndpointAnnotator.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/CamelEndpointAnnotator.java
@@ -35,7 +35,6 @@ import org.apache.camel.idea.util.CamelIdeaUtils;
 import org.apache.camel.idea.util.IdeaUtils;
 import org.jetbrains.annotations.NotNull;
 
-import static org.apache.camel.idea.util.CamelIdeaUtils.acceptForAnnotatorOrInspection;
 import static org.apache.camel.idea.util.CamelIdeaUtils.skipEndpointValidation;
 import static org.apache.camel.idea.util.StringUtils.isEmpty;
 
@@ -68,13 +67,8 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
                 return;
             }
 
-            if (!acceptForAnnotatorOrInspection(element)) {
-                LOG.debug("Skipping complex element  " + element + " for validation with text: " + uri);
-                return;
-            }
-
             // camel catalog expects &amp; as & when it parses so replace all &amp; as &
-            String camelQuery = uri;
+            String camelQuery = IdeaUtils.getInnerText(uri);
             camelQuery = camelQuery.replaceAll("&amp;", "&");
 
             // strip up ending incomplete parameter
@@ -126,7 +120,7 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
                 int propertyIdx = fromElement.indexOf(propertyValue, startIdxQueryParameters);
                 int propertyLength = propertyValue.length();
 
-                propertyIdx = IdeaUtils.isJavaLanguage(element) || IdeaUtils.isXmlLanguage(element) || IdeaUtils.isScalaLanguage(element) ? propertyIdx + 1 : propertyIdx;
+                propertyIdx = IdeaUtils.isJavaLanguage(element) || IdeaUtils.isXmlLanguage(element) || IdeaUtils.isScalaLanguage(element) ? propertyIdx + 1  : propertyIdx;
 
                 TextRange range = new TextRange(element.getTextRange().getStartOffset() + propertyIdx,
                     element.getTextRange().getStartOffset() + propertyIdx + propertyLength);

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/CamelSimpleAnnotator.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/CamelSimpleAnnotator.java
@@ -21,7 +21,6 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.impl.source.tree.java.PsiLiteralExpressionImpl;
 import com.intellij.psi.xml.XmlAttributeValue;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.SimpleValidationResult;
@@ -31,14 +30,11 @@ import org.apache.camel.idea.service.CamelService;
 import org.apache.camel.idea.util.CamelIdeaUtils;
 import org.jetbrains.annotations.NotNull;
 
-import static org.apache.camel.idea.util.CamelIdeaUtils.acceptForAnnotatorOrInspection;
 import static org.apache.camel.idea.util.CamelIdeaUtils.isCameSimpleExpressionUsedAsPredicate;
 import static org.apache.camel.idea.util.IdeaUtils.isFromGroovyMethod;
-import static org.apache.camel.idea.util.IdeaUtils.isGroovyLanguage;
 import static org.apache.camel.idea.util.IdeaUtils.isJavaLanguage;
 import static org.apache.camel.idea.util.IdeaUtils.isKotlinLanguage;
 import static org.apache.camel.idea.util.IdeaUtils.isScalaLanguage;
-import static org.apache.camel.idea.util.IdeaUtils.isXmlLanguage;
 
 /**
  * Validate simple expression and annotated the specific simple expression to highlight the error in the editor
@@ -63,11 +59,6 @@ public class CamelSimpleAnnotator extends AbstractCamelAnnotator {
         if (hasSimple && CamelIdeaUtils.isCamelSimpleExpression(element)) {
             CamelCatalog catalogService = ServiceManager.getService(element.getProject(), CamelCatalogService.class).get();
             CamelService camelService = ServiceManager.getService(element.getProject(), CamelService.class);
-
-            if (!acceptForAnnotatorOrInspection(element)) {
-                LOG.debug("Skipping complex element  " + element + " for validation simple: " + text);
-                return;
-            }
 
             boolean predicate = false;
             try {

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/CamelContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/CamelContributor.java
@@ -87,12 +87,12 @@ public abstract class CamelContributor extends CompletionContributor {
     private static String[] parsePsiElement(@NotNull CompletionParameters parameters) {
         PsiElement element = parameters.getPosition();
 
-        String val = extractTextFromElement(element, true, true);
+        String val = extractTextFromElement(element, true, true, true);
         if (val == null || val.isEmpty()) {
             return new String[]{"", ""};
         }
 
-        String valueAtPosition = extractTextFromElement(element, true, false);
+        String valueAtPosition = extractTextFromElement(element, true, false, true);
 
         String suffix = "";
 

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/CamelSmartCompletionEndpointOptions.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/CamelSmartCompletionEndpointOptions.java
@@ -232,7 +232,9 @@ public final class CamelSmartCompletionEndpointOptions {
         //to compare the string against known options we need to strip it from equal sign
         String searchStr = strToRemove[0];
         if (!searchStr.isEmpty() && !searchStr.endsWith("&") && existing != null) {
-            searchStr =  searchStr.substring(1);
+            if (searchStr.startsWith("&") || searchStr.startsWith("?")) {
+                searchStr = searchStr.substring(1);
+            }
             //check if the option is known option
             final String optionToRemove = existing.get(searchStr);
             if (optionToRemove == null || optionToRemove.isEmpty()) {

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/inspection/AbstractCamelInspection.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/inspection/AbstractCamelInspection.java
@@ -92,7 +92,7 @@ public abstract class AbstractCamelInspection extends LocalInspectionTool {
                 @Override
                 public void visitElement(PsiElement element) {
                     if (accept(element)) {
-                        String text = IdeaUtils.extractTextFromElement(element, false, false);
+                        String text = IdeaUtils.extractTextFromElement(element, false, false, true);
                         if (!StringUtils.isEmpty(text)) {
                             validateText(element, holder, text, isOnTheFly);
                         }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/intention/CamelAddEndpointIntention.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/intention/CamelAddEndpointIntention.java
@@ -118,7 +118,7 @@ public class CamelAddEndpointIntention extends PsiElementBaseIntentionAction imp
                 }
             } else {
                 // should be a literal element and therefore dont fallback to generic
-                text = extractTextFromElement(element, false, false);
+                text = extractTextFromElement(element, false, false, true);
             }
 
             return text != null && text.trim().isEmpty();

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/IdeaUtils.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/IdeaUtils.java
@@ -95,6 +95,9 @@ public final class IdeaUtils {
             PsiLiteralExpression literal = (PsiLiteralExpression) element;
             Object o = literal.getValue();
             String text = o != null ? o.toString() : null;
+            if (text == null) {
+                return "";
+            }
             if (concatString) {
                 final PsiPolyadicExpression parentOfType = PsiTreeUtil.getParentOfType(element, PsiPolyadicExpression.class);
                 if (parentOfType != null) {

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -29,7 +29,7 @@
 
   <change-notes><![CDATA[
       <ul>
-        <li>0.3.8 - Work in progress.</li>
+        <li>0.3.8 - Support for code completion and validation with multi-line endpoint URI</li>
         <li>0.3.7 - Added support for Gradle based projects.
                     Code completion improved to jump to position based on prefixed values.
                     Navigate to linked Camel routes by clicking the Camel gutter icon.

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelEndpointAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelEndpointAnnotatorTestIT.java
@@ -113,6 +113,26 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
         myFixture.checkHighlighting(false, false, true, true);
     }
 
+    public void testJavaMultilineTest1SearchDataValidation() {
+        myFixture.configureByText("myjavacode.java", getJavaMultilineTestValidationData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
+
+    public void testJavaMultilineTest2SearchDataValidation() {
+        myFixture.configureByText("myjavacode.java", getJavaMultilineTest2ValidationData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
+
+    public void testXmlMultilineTestSearchDataValidation() {
+        myFixture.configureByText("myxmlcode.xml", getXmlMultilineTest1ValidationData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
+
+    public void testXmlMultilineTest2SearchDataValidation() {
+        myFixture.configureByText("myxmlcode.xml", getXmlMultilineTest2ValidationData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
+
     public void testAnnotatorConsumerOnly() {
         myFixture.configureByText("AnnotatorTestData.java", getJavaConsumerOnlyTestData());
         myFixture.checkHighlighting(false, false, true, true);
@@ -308,6 +328,55 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
             + "                .to(\"file:outbox\");\n"
             + "        }\n"
             + "    }";
+    }
+
+    private String getJavaMultilineTestValidationData() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger?repeatCount=10\"+\n"
+            + "                 \"&fixedRate=false\"+\n"
+            + "                 \"&daemon=false&\" \n"
+            + "                + \"<error descr=\"Unknown option\">pexriod</error>=10\");\n"
+            + "        }\n"
+            + "    }";
+    }
+
+    private String getJavaMultilineTest2ValidationData() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger?repeatCount=10\"+\n"
+            + "                 \"&fixedRate=<error descr=\"Invalid boolean value: falxse\">falxse</error>\"+\n"
+            + "                 \"&daemon=false&\" \n"
+            + "                + \"<error descr=\"Unknown option\">pexriod</error>=10\");\n"
+            + "        }\n"
+            + "    }";
+    }
+
+    private String getXmlMultilineTest1ValidationData() {
+        return "<routes>\n"
+            + "  <route>\n"
+            + "    <from uri=\"timer:trigger?repeatCount=10\n"
+            + "         &amp;ex<caret>fixedRate=false\n"
+            + "         &amp;daemon=false\n"
+            + "         &amp;<error descr=\"Unknown option\">pexriod</error>=10\"/>"
+            + "    <to uri=\"file:outbox?delete=true&amp;fileExist=Append\"/>\n"
+            + "  </route>\n"
+            + "</routes>";
+
+    }
+    private String getXmlMultilineTest2ValidationData() {
+        return "<routes>\n"
+            + "  <route>\n"
+            + "    <from uri=\"timer:trigger?repeatCount=10\n"
+            + "         &amp;ex<caret>fixedRate=false\n"
+            + "         &amp;daemon=<error descr=\"Invalid boolean value: falxse\">falxse</error>\n"
+            + "         &amp;<error descr=\"Unknown option\">pexriod</error>=10\"/>"
+            + "    <to uri=\"file:outbox?delete=true&amp;fileExist=Append\"/>\n"
+            + "  </route>\n"
+            + "</routes>";
+
     }
 
 }

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelEndpointAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelEndpointAnnotatorTestIT.java
@@ -123,6 +123,11 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
         myFixture.checkHighlighting(false, false, true, true);
     }
 
+    public void testJavaMultilineDoubleQuoteEndingStringTestValidationData() {
+        myFixture.configureByText("myjavacode.java", getJavaMultilineDoubleQuoteEndingStringTestValidationData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
+
     public void testXmlMultilineTestSearchDataValidation() {
         myFixture.configureByText("myxmlcode.xml", getXmlMultilineTest1ValidationData());
         myFixture.checkHighlighting(false, false, true, true);
@@ -354,6 +359,18 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
             + "    }";
     }
 
+    private String getJavaMultilineDoubleQuoteEndingStringTestValidationData() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger?repeatCount=10\"+\n"
+            + "                 \"&fixedRate=<error descr=\"Invalid boolean value: falxse\">falxse</error>\"+\n"
+            + "                 \"&daemon=false&\" \n"
+            + "                + \"<error descr=\"Unknown option\">pexriod</error>=10\"\");\n"
+            + "        }\n"
+            + "    }";
+    }
+
     private String getXmlMultilineTest1ValidationData() {
         return "<routes>\n"
             + "  <route>\n"
@@ -378,5 +395,6 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
             + "</routes>";
 
     }
+
 
 }

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelSimpleAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelSimpleAnnotatorTestIT.java
@@ -67,6 +67,11 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
         myFixture.checkHighlighting(false, false, false, true);
     }
 
+    public void testAnnotatorJavaMultilinePredicateValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaMultilinePredicate());
+        myFixture.checkHighlighting(false, false, false, true);
+    }
+
     public void testAnnotatorCamelPredicateValidation2() {
         myFixture.configureByText("AnnotatorTestData.java", getJavaWithCamelPredicate2());
         myFixture.checkHighlighting(false, false, false, true);
@@ -173,6 +178,24 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
             + "                .transform(body().append(\"A\"))\n"
             + "                .end()\n"
             + "                .to(\"mock:result\");"
+            + "        }\n"
+            + "    }";
+    }
+
+    private String getJavaMultilinePredicate() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + " from(\"timer:trigger\")\n"
+            + "            .choice()\n"
+            + "                .when(xpath(\"/person/city = 'London'\"))\n"
+            + "                    .log(\"UK message\"+\n"
+            + "                            \"with info <error descr=\"Unknown function: boxdy\">${boxdy}</error>\" +\n"
+            + "                            \"file:${fxile:name}\")\n"
+            + "                    .to(\"file:target/messages/uk\")\n"
+            + "                .otherwise()\n"
+            + "                    .log(\"Other message\")\n"
+            + "                    .to(\"file:target/messages/others\");"
             + "        }\n"
             + "    }";
     }

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaEndpointSmartCompletionTestIT.java
@@ -211,7 +211,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         List<String> strings = myFixture.getLookupElementStrings();
         assertEquals("There is many options", 8, strings.size());
         assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
-            "timer:trigger?repeatCount=10&",
+            "timer:trigger?repeatCount=10",
             "&fixedRate=false",
             "&daemon=false",
             "&period=10")));
@@ -237,7 +237,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         List<String> strings = myFixture.getLookupElementStrings();
         assertEquals("There is many options", 8, strings.size());
         assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
-            "timer:trigger?repeatCount=10&",
+            "timer:trigger?repeatCount=10",
             "&fixedRate=false",
             "&daemon=false",
             "&period=10")));
@@ -264,13 +264,39 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         assertEquals("There is many options", 2, strings.size());
         assertThat(strings, Matchers.containsInAnyOrder("&exceptionHandler", "&exchangePattern"));
         assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
-            "timer:trigger?repeatCount=10&",
+            "timer:trigger?repeatCount=10",
             "&fixedRate=false",
             "&daemon=false",
             "&period=10")));
         myFixture.type('\n');
         String javaInsertAfterQuestionMarkTestData = getJavaMultilineInFixSearchData().replace("<caret>", "ceptionHandler=");
         myFixture.checkResult(javaInsertAfterQuestionMarkTestData);
+    }
+
+    private String getJavaMultilineTest4SearchData() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger?repeatCount=10\"+\n"
+            + "                 \"&fixedRate=false\"+\n"
+            + "                 \"&daemon=false&\" \n"
+            + "                + \"period=10<caret>\");\n"
+            + "        }\n"
+            + "    }";
+    }
+    public void testJavaMultilineTest4Data() {
+        myFixture.configureByText("CamelRoute.java", getJavaMultilineTest4SearchData());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals("There is many options", 8, strings.size());
+        assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
+            "timer:trigger?repeatCount=10",
+            "fixedRate=false",
+            "daemon=false",
+            "period=10")));
+        myFixture.type('\n');
+        String javaMarkTestData = getJavaMultilineTest4SearchData().replace("<caret>", "&bridgeErrorHandler=");
+        myFixture.checkResult(javaMarkTestData);
     }
 
 


### PR DESCRIPTION
This add basic support for multi line endpoint validation and multi line simple validation.

For other languges this feature is still missing and will require little more because we can't utilize the Scala PSI classes since the camel plug-in dosen't have a required dependency on other languges