### PR TITLE
Fixed version presence check in CamelService.scanForCamelProject 

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
@@ -183,10 +183,12 @@ public class CamelService implements Disposable {
                         || split[0].equalsIgnoreCase("sbt")) {
                         startIdx = 1;
                     }
+                    boolean hasVersion = split.length > (startIdx + 2);
+
                     String groupId = split[startIdx++].trim();
                     String artifactId = split[startIdx++].trim();
                     String version = null;
-                    if (split.length > 2) {
+                    if (hasVersion) {
                         version = split[startIdx].trim();
                     }
 

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/service/CamelServiceTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/service/CamelServiceTestIT.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.idea.service;
+
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.testFramework.PsiTestUtil;
+import com.intellij.testFramework.exceptionCases.AbstractExceptionCase;
+import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import org.junit.Test;
+
+public class CamelServiceTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+    
+    @Test
+    public void testScanForCamelProjectShouldSupportDependenciesWithoutVersion() throws Throwable {
+        CamelService service = ServiceManager.getService(myModule.getProject(), CamelService.class);
+        assertNoException(ArrayIndexOutOfBoundsExceptionCase.check(
+            () -> PsiTestUtil.addProjectLibrary(myModule, "gradle::mylib:"))
+        );
+        assertTrue(service.isCamelPresent());
+        assertNoException(ArrayIndexOutOfBoundsExceptionCase.check(
+            () -> PsiTestUtil.addProjectLibrary(myModule, "gradle:mygroup:myartifactId:"))
+        );
+        assertNoException(ArrayIndexOutOfBoundsExceptionCase.check(
+            () -> PsiTestUtil.addProjectLibrary(myModule, "mygroup:myartifactId:"))
+        );
+    }
+
+}
+
+abstract class ArrayIndexOutOfBoundsExceptionCase extends AbstractExceptionCase<ArrayIndexOutOfBoundsException> {
+
+    @Override
+    public Class<ArrayIndexOutOfBoundsException> getExpectedExceptionClass() {
+        return ArrayIndexOutOfBoundsException.class;
+    }
+
+    static ArrayIndexOutOfBoundsExceptionCase check(Runnable runnable) {
+        return new ArrayIndexOutOfBoundsExceptionCase() {
+            @Override
+            public void tryClosure() throws ArrayIndexOutOfBoundsException {
+                runnable.run();
+            }
+        };
+    }
+}


### PR DESCRIPTION
fixes #294
Considers also startIdx when checking for version presence